### PR TITLE
Fix frontend dev server url for mobile (it doesn't work on mobile without this change)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,13 @@ import solidJs from "@astrojs/solid-js";
 import playformCompress from "@playform/compress";
 import playformInline from "@playform/inline";
 
+const mobile = !!/android|ios/.exec(process.env.TAURI_ENV_PLATFORM);
+
 // https://astro.build/config
 export default defineConfig({
+  server: {
+    host: mobile ? "0.0.0.0" : false,
+    port: 4321,
+  },
   integrations: [solidJs(), playformInline(), playformCompress()]
 });


### PR DESCRIPTION
When trying to launch Tauri Mobile, there's an error that prevents Tauri from functioning properly.

I've followed the example from vite.config.mjs and the Astro docs.

Links:
https://github.com/tauri-apps/tauri/blob/dev/examples/api/vite.config.js
https://docs.astro.build/en/reference/configuration-reference/#server-options

Screenshots:
Before:
![Captura desde 2024-04-27 22-23-21](https://github.com/JonasKruckenberg/tauri-astro-template/assets/56872592/0bd61bfb-8256-4946-9610-5a3bbf683d58)

After:
![Captura desde 2024-04-27 22-26-07](https://github.com/JonasKruckenberg/tauri-astro-template/assets/56872592/e1647b9c-f3e9-49d2-9a5f-0d190766c720)
